### PR TITLE
Fix linking in OBS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ $(DEPFILES):
 include $(wildcard $(DEPFILES))
 
 $(TARGET): $(OBJS)
-	cc ${LDFLAGS} -lm -o $(TARGET) $(OBJS)
+	cc -o $(TARGET) $(OBJS) ${LDFLAGS} -lm 
 
 ifeq ($(PREFIX),)
   PREFIX := /usr/local


### PR DESCRIPTION
Hi,

This fixes the linking order. Otherwise it fails to build in https://build.opensuse.org/package/show/multimedia:proaudio/alsa-scarlett-gui