### PR TITLE
set minimum size of widget-boolean to the largest of the two labels

### DIFF
--- a/src/widget-boolean.c
+++ b/src/widget-boolean.c
@@ -9,6 +9,21 @@ static void button_clicked(GtkWidget *widget, struct alsa_elem *elem) {
   alsa_set_elem_value(elem, value);
 }
 
+
+static void toggle_button_set_text(struct alsa_elem *elem, const char *text)
+{
+  if (text) {
+    if (*text == '*') {
+      GtkWidget *icon = gtk_image_new_from_icon_name(text + 1);
+      gtk_button_set_child(GTK_BUTTON(elem->widget), icon);
+    } else {
+      gtk_button_set_label(
+        GTK_BUTTON(elem->widget), text
+      );
+    }
+  }
+}
+
 static void toggle_button_updated(struct alsa_elem *elem) {
   int is_writable = alsa_get_elem_writable(elem);
   gtk_widget_set_sensitive(elem->widget, is_writable);
@@ -16,17 +31,7 @@ static void toggle_button_updated(struct alsa_elem *elem) {
   int value = alsa_get_elem_value(elem);
   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(elem->widget), value);
 
-  const char *text = elem->bool_text[value];
-  if (text) {
-    if (*text == '*') {
-      GtkWidget *icon = gtk_image_new_from_icon_name(text + 1);
-      gtk_button_set_child(GTK_BUTTON(elem->widget), icon);
-    } else {
-      gtk_button_set_label(
-        GTK_BUTTON(elem->widget), elem->bool_text[value]
-      );
-    }
-  }
+  toggle_button_set_text(elem, elem->bool_text[value]);  
 }
 
 GtkWidget *make_boolean_alsa_elem(
@@ -43,7 +48,19 @@ GtkWidget *make_boolean_alsa_elem(
   elem->widget_callback = toggle_button_updated;
   elem->bool_text[0] = disabled_text;
   elem->bool_text[1] = enabled_text;
-
+  
+  // get sizes of both possible labels
+  int min_width = 0, min_height = 0;
+  for (int i = 0; i < 2; i++)
+  {
+    toggle_button_set_text(elem, elem->bool_text[i]);
+    GtkRequisition* min_size = gtk_requisition_new();
+    gtk_widget_get_preferred_size(button, min_size, NULL);
+    if (min_size->width  > min_width)  min_width  = min_size->width;
+    if (min_size->height > min_height) min_height = min_size->height;
+  }
+  gtk_widget_set_size_request(button, min_width, min_height);
+  
   toggle_button_updated(elem);
 
   return button;


### PR DESCRIPTION
The boolean toggle buttons change their minimal size when the label changes. When both "Air" and "Pad" are set to "on" on one of channels 3-8 of the 18i20, the whole layout changes a bit. This commit gets the maximal size of both possible labels and sets the widget's minimum size accordingly.