### PR TITLE
Add keyword to desktop file

### DIFF
--- a/src/vu.b4.alsa-scarlett-gui.desktop.template
+++ b/src/vu.b4.alsa-scarlett-gui.desktop.template
@@ -7,3 +7,4 @@ Name=ALSA Scarlett Gen 2/3 Control Panel
 Icon=alsa-scarlett-gui
 Exec=PREFIX/bin/alsa-scarlett-gui
 Categories=GTK;AudioVideo;Audio;Mixer;
+Keywords=focusrite;


### PR DESCRIPTION
Add "focusrite" as a keyword to Desktop file. This one was bothering me a lot when I searched for the app using GNOME ...so I figured I may as well contribute the keyword addition upstream! Thanks for the great software.