### PR TITLE
src/Makefile: Respect CFLAGS from environment

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ VERSION := $(shell \
 DEPDIR := .deps
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
 
-CFLAGS := -Wall -Werror -ggdb -fno-omit-frame-pointer -O2 -D_FORTIFY_SOURCE=2
+CFLAGS += -Wall -Werror -ggdb -fno-omit-frame-pointer -O2 -D_FORTIFY_SOURCE=2
 CFLAGS += -DVERSION=\"$(VERSION)\"
 CFLAGS += -Wno-error=deprecated-declarations
 


### PR DESCRIPTION
Minor tweak to the Makefile so that it respects CFLAGS passed in from the environment. This may be useful for anyone that wishes to customise their build, but in particular it's required by [Debian's hardening guidelines](https://wiki.debian.org/Hardening), which require security hardening CFLAGS to be passed to GCC during package builds.