### PR TITLE
Makefile: prefer distro cflags if specified

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,8 @@ VERSION := $(shell \
 DEPDIR := .deps
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
 
-CFLAGS += -Wall -Werror -ggdb -fno-omit-frame-pointer -O2 -D_FORTIFY_SOURCE=2
+CFLAGS ?= -ggdb -fno-omit-frame-pointer -O2
+CFLAGS += -Wall -Werror -D_FORTIFY_SOURCE=2
 CFLAGS += -DVERSION=\"$(VERSION)\"
 CFLAGS += -Wno-error=deprecated-declarations
 


### PR DESCRIPTION
The compilation flags that are necessary for building and part of the developer's intentions belong in the `+=` section, but the base flags that distros like to override belong in a `?=` section, so that build systems using their own are respected.