### PR TITLE
Include openssl-devel to installation instructions.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ On Fedora, the packages `alsa-lib-devel` and `gtk4-devel` need to be
 installed:
 
 ```
-sudo dnf -y install alsa-lib-devel gtk4-devel
+sudo dnf -y install alsa-lib-devel gtk4-devel openssl-devel
 ```
 
 On OpenSUSE:


### PR DESCRIPTION
I had problems while compiling this using an RPM-based distro because `openssl-devel` was missing:

```
scarlett2-firmware.c:9:10: fatal error: openssl/sha.h: No such file or directory
    9 | #include <openssl/sha.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:50: scarlett2-firmware.o] Error 1
make: *** Waiting for unfinished jobs....
```
