### PR TITLE
Add dependencies on deb package

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -42,6 +42,7 @@ jobs:
           package: ${{ env.APP_NAME }}
           package_root: ${{ github.workspace }}/deb-workspace
           maintainer: geoffreybennett
+          depends: 'libgtk-4-1, libasound2, alsa-utils'
           version: ${{ env.APP_VERSION }}
           desc: ${{ env.APP_NAME }} is a Gtk4 GUI for the ALSA controls presented by the Linux kernel Focusrite Scarlett Gen 2/3 Mixer Driver.
 


### PR DESCRIPTION
Hello,

Would this fix #109 ?

How did I test:
```
$ sudo apt remove libgtk-4-1
$ sudo apt install ./alsa-scarlett-gui_0.4.1_amd64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'alsa-scarlett-gui' instead of './alsa-scarlett-gui_0.4.1_amd64.deb'
The following packages were automatically installed and are no longer required:
  gir1.2-graphene-1.0 libgraphene-1.0-dev
Use 'sudo apt autoremove' to remove them.
The following additional packages will be installed:
  libgtk-4-1 libgtk-4-bin
Suggested packages:
  libgtk-4-media-gstreamer | libgtk-4-media-ffmpeg
The following NEW packages will be installed:
  alsa-scarlett-gui libgtk-4-1 libgtk-4-bin
0 upgraded, 3 newly installed, 0 to remove and 27 not upgraded.
Need to get 5 736 kB/9 309 kB of archives.
After this operation, 22,6 MB of additional disk space will be used.
Do you want to continue? [Y/n]  
```

Gwilherm.