### PR TITLE
Update Makefile to build with LLD specific flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,7 +66,7 @@ $(DEPFILES):
 include $(wildcard $(DEPFILES))
 
 $(TARGET): $(OBJS)
-	cc -o $(TARGET) $(OBJS) ${LDFLAGS}
+	$(CC) -o $(TARGET) $(OBJS) ${LDFLAGS}
 
 ifeq ($(PREFIX),)
   PREFIX := /usr/local


### PR DESCRIPTION
Calling cc directly during link time causes a build failure on Clang/LLVM based Gentoo machines that use LLVM specific toolchain flags. For example, LLD has the flag --icf=all and when passed to LDFLAGS the build will error out:

```
cc -o alsa-scarlett-gui about.o alsa-scarlett-gui-resources.o alsa-sim.o alsa.o device-reset-config.o device-update-firmware.o error.o file.o gtkdial.o gtkhelper.o hardware.o iface-mixer.o iface-no-mixer.o iface-none.o iface-unknown.o iface-update.o main.o menu.o routing-drag-line.o routing-lines.o scarlett2-firmware.o scarlett2-ioctls.o stringhelper.o tooltips.o widget-boolean.o widget-drop-down.o widget-dual.o widget-gain.o widget-input-select.o widget-label.o widget-sample-rate.o window-hardware.o window-helper.o window-iface.o window-levels.o window-mixer.o window-modal.o window-routing.o window-startup.o -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs -Wl,--as-needed -Wl,--as-needed -Wl,--gc-sections -Wl,--icf=all -Wl,-O2 -Wl,-z,now -Wl,-z,relro -Wl,--defsym=__gentoo_check_ldflags__=0 -lglib-2.0 -lgtk-4 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -lgdk_pixbuf-2.0 -lcairo-gobject -lcairo -lvulkan -lgraphene-1.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lasound -lm -lcrypto
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: unrecognized option '--icf=all'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: use the --help option for usage information
collect2: error: ld returned 1 exit status
```

A very simple patch that addresses this issue.