### PR TITLE
Add `alsactl` utility to Flatpak version

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -94,23 +94,41 @@ to the user manual of your interface for more information.
 
 The settings in the ALSA Scarlett Control Panel are automatically
 saved in the interface itself (all series except 1st Gen), so they
-“should” persist across reboots and even across different computers.
+should persist across reboots, power cycles, USB disconnect/reconnect,
+and even across different computers. This includes all routing,
+mixing, and other control panel settings.
 
-If you find that the opposite is happening — that every time you plug
-your interface in, the settings get reverted, try disabling the
-`alsa-state` and `alsa-restore` systemd services:
+If you find that your settings are reverting whenever you plug your
+interface in or power it back on, the most likely cause is the
+`alsa-state` and `alsa-restore` systemd services. These services save
+the state of ALSA controls on system shutdown to
+`/var/lib/alsa/asound.state` and then restore it each time the device
+is plugged in, potentially overwriting your interface’s stored
+settings.
+
+It can be rather annoying, wondering why your device is unusable or
+needs to be reconfigured every time you plug it in or turn it on.
+
+To fix this issue, disable these services:
 
 ```sh
 sudo systemctl mask alsa-state
 sudo systemctl mask alsa-restore
 ```
 
-These services save the state of ALSA controls on system shutdown to
-`/var/lib/alsa/asound.state` and then restore it each time the device
-is plugged in. It can be rather annoying, wondering why your device is
-unusable every time you plug it in, only to find that it’s because you
-once shut down your computer with the Clock Source set to “ADAT” or
-some such thing.
+You can verify if this is the case of your issues by:
+
+1. Change some setting that is indicated on the device (the “Inst”
+   setting is a good).
+2. Disconnect USB.
+3. Notice the state of the setting on the device has not changed.
+4. Power cycle the device.
+5. Notice the state of the setting on the device has not changed.
+6. Reconnect USB.
+7. Notice the state of the setting on the device has changed.
+
+If the setting on the device changes at step 7, then the `alsa-state`
+and `alsa-restore` services are the likely cause of your issues.
 
 ## Help?!
 

--- a/vu.b4.alsa-scarlett-gui.yml
+++ b/vu.b4.alsa-scarlett-gui.yml
@@ -66,7 +66,9 @@ modules:
       # - type: git
       #   url: https://github.com/geoffreybennett/alsa-scarlett-gui.git
       #   tag: "0.2"
-
+    cleanup:
+      - /lib/debug
+      - /lib/source
   - name: scarlett2-firmware
     buildsystem: simple
     build-commands:

--- a/vu.b4.alsa-scarlett-gui.yml
+++ b/vu.b4.alsa-scarlett-gui.yml
@@ -56,9 +56,6 @@ modules:
       - /share/runtime
       - /share/sounds
   - name: alsa-scarlett-gui
-    buildsystem: simple
-    build-commands:
-      - make -j8 install PREFIX=$FLATPAK_DEST
     sources:
       - type: dir
         path: ./src
@@ -66,15 +63,18 @@ modules:
       # - type: git
       #   url: https://github.com/geoffreybennett/alsa-scarlett-gui.git
       #   tag: "0.2"
+    buildsystem: simple
+    build-commands:
+      - make -j8 install PREFIX=$FLATPAK_DEST
     cleanup:
       - /lib/debug
       - /lib/source
   - name: scarlett2-firmware
-    buildsystem: simple
-    build-commands:
-      - mkdir -p $FLATPAK_DEST/lib/firmware/scarlett2
-      - cp -a LICENSE.Focusrite firmware/* $FLATPAK_DEST/lib/firmware/scarlett2
     sources:
       - type: archive
         url: https://github.com/geoffreybennett/scarlett2-firmware/archive/refs/tags/2128b.tar.gz
         sha256: 4a17fdbe2110855c2f7f6cfc5ea1894943a6e58770f3dff5ef283961f8ae2a03
+    buildsystem: simple
+    build-commands:
+      - mkdir -p $FLATPAK_DEST/lib/firmware/scarlett2
+      - cp -a LICENSE.Focusrite firmware/* $FLATPAK_DEST/lib/firmware/scarlett2

--- a/vu.b4.alsa-scarlett-gui.yml
+++ b/vu.b4.alsa-scarlett-gui.yml
@@ -17,6 +17,44 @@ finish-args:
   # Point to the firmware directory
   - --env=SCARLETT2_FIRMWARE_DIR=/app/lib/firmware/scarlett2
 modules:
+  - name: alsa-utils
+    sources:
+      - type: archive
+        url: https://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.12.tar.bz2
+        sha256: 4868cd908627279da5a634f468701625be8cc251d84262c7e5b6a218391ad0d2
+        dest: .deps/alsa-lib
+      - type: archive
+        url: https://www.alsa-project.org/files/pub/utils/alsa-utils-1.2.12.tar.bz2
+        sha256: 98bc6677d0c0074006679051822324a0ab0879aea558a8f68b511780d30cd924
+    buildsystem: autotools
+    config-opts:
+      # We are only interested in alsactl
+      - --bindir=/app/null
+      - --with-udev-rules-dir=/app/null
+      - --with-systemdsystemunitdir=/app/null
+      # https://github.com/alsa-project/alsa-utils/issues/33
+      - --enable-alsa-topology
+      - --disable-alsaconf
+      - --disable-alsatest
+      - --disable-alsabat-backend-tiny
+      - --disable-alsamixer
+      - --disable-alsaloop
+      - --disable-nhlt
+      - --disable-xmlto
+      - --disable-rst2man
+      - --with-alsa-inc-prefix=.deps/alsa-lib/include
+    post-install:
+      - install -Dm755 /app/sbin/alsactl /app/bin/alsactl
+    cleanup:
+      - /lib/debug
+      - /lib/alsa-topology
+      - /null
+      - /sbin
+      - /share/alsa
+      - /share/locale
+      - /share/man
+      - /share/runtime
+      - /share/sounds
   - name: alsa-scarlett-gui
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Allows saving and loading device state with the Flatpak version. The Gnome 47 SDK [uses alsa-lib 1.2.12][1] via [the Freedesktop.org SDK][2], so we use that here as well. Tested saving and loading with my Clarett+ 2Pre and it appears to work.

Also do some minor cleanup in the Flatpak manifest: Removing some leftover files, reorder module configuration. Let me know if I should drop the cleanup commits! o7

Fixes https://github.com/geoffreybennett/alsa-scarlett-gui/issues/122.

[1]: https://gitlab.gnome.org/search?search=alsa&nav_source=navbar&project_id=456&group_id=8&search_code=true&repository_ref=47.4
[2]: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/24.08/elements/components/alsa-lib.bst?ref_type=heads