### PR TITLE
Add "S/PDIF Source" Control

### DIFF
--- a/demo/Clarett 8Pre USB.state
+++ b/demo/Clarett 8Pre USB.state
@@ -1,0 +1,6490 @@
+state.USB {
+	control.1 {
+		iface CARD
+		name 'Internal Validity'
+		value true
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.2 {
+		iface CARD
+		name 'S/PDIF Validity'
+		value true
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.3 {
+		iface CARD
+		name 'ADAT Validity'
+		value true
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Clock Source Clock Source'
+		value Internal
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Internal
+			item.1 S/PDIF
+			item.2 ADAT
+		}
+	}
+	control.5 {
+		iface CARD
+		name 'Firmware Version'
+		value 1195
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 0'
+		}
+	}
+	control.6 {
+		iface CARD
+		name 'Minimum Firmware Version'
+		value 0
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 0'
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'Master HW Playback Volume'
+		value 96
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'Line 01 (Monitor L) Playback Volume'
+		value 96
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'Line 01 Mute Playback Switch'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'Line Out 01 Volume Control Playback Enum'
+		value HW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'Line 02 (Monitor R) Playback Volume'
+		value 96
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'Line 02 Mute Playback Switch'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'Line Out 02 Volume Control Playback Enum'
+		value HW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'Line 03 Playback Volume'
+		value 96
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'Line 03 Mute Playback Switch'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'Line Out 03 Volume Control Playback Enum'
+		value HW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'Line 04 Playback Volume'
+		value 96
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'Line 04 Mute Playback Switch'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.19 {
+		iface MIXER
+		name 'Line Out 04 Volume Control Playback Enum'
+		value HW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.20 {
+		iface MIXER
+		name 'Line 05 Playback Volume'
+		value 96
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.21 {
+		iface MIXER
+		name 'Line 05 Mute Playback Switch'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.22 {
+		iface MIXER
+		name 'Line Out 05 Volume Control Playback Enum'
+		value HW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.23 {
+		iface MIXER
+		name 'Line 06 Playback Volume'
+		value 96
+		comment {
+			access read
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.24 {
+		iface MIXER
+		name 'Line 06 Mute Playback Switch'
+		value false
+		comment {
+			access read
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.25 {
+		iface MIXER
+		name 'Line Out 06 Volume Control Playback Enum'
+		value HW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.26 {
+		iface MIXER
+		name 'Line 07 (Headphones 1 L) Playback Volume'
+		value 100
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -2700
+		}
+	}
+	control.27 {
+		iface MIXER
+		name 'Line 07 Mute Playback Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.28 {
+		iface MIXER
+		name 'Line Out 07 Volume Control Playback Enum'
+		value SW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'Line 08 (Headphones 1 R) Playback Volume'
+		value 100
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -2700
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'Line 08 Mute Playback Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.31 {
+		iface MIXER
+		name 'Line Out 08 Volume Control Playback Enum'
+		value SW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.32 {
+		iface MIXER
+		name 'Line 09 (Headphones 2 L) Playback Volume'
+		value 100
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -2700
+		}
+	}
+	control.33 {
+		iface MIXER
+		name 'Line 09 Mute Playback Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.34 {
+		iface MIXER
+		name 'Line Out 09 Volume Control Playback Enum'
+		value SW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.35 {
+		iface MIXER
+		name 'Line 10 (Headphones 2 R) Playback Volume'
+		value 96
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 127 (step 1)'
+			dbmin -12700
+			dbmax 0
+			dbvalue.0 -3100
+		}
+	}
+	control.36 {
+		iface MIXER
+		name 'Line 10 Mute Playback Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.37 {
+		iface MIXER
+		name 'Line Out 10 Volume Control Playback Enum'
+		value SW
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 SW
+			item.1 HW
+		}
+	}
+	control.38 {
+		iface MIXER
+		name 'Mute Playback Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.39 {
+		iface MIXER
+		name 'Dim Playback Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.40 {
+		iface MIXER
+		name 'Line In 1 Level Capture Enum'
+		value Inst
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Line
+			item.1 Inst
+		}
+	}
+	control.41 {
+		iface MIXER
+		name 'Line In 2 Level Capture Enum'
+		value Inst
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Line
+			item.1 Inst
+		}
+	}
+	control.42 {
+		iface MIXER
+		name 'Line In 1 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.43 {
+		iface MIXER
+		name 'Line In 2 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.44 {
+		iface MIXER
+		name 'Line In 3 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.45 {
+		iface MIXER
+		name 'Line In 4 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.46 {
+		iface MIXER
+		name 'Line In 5 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.47 {
+		iface MIXER
+		name 'Line In 6 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.48 {
+		iface MIXER
+		name 'Line In 7 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.49 {
+		iface MIXER
+		name 'Line In 8 Air Capture Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.50 {
+		iface MIXER
+		name 'Analogue Output 01 Playback Enum'
+		value 'Mix A'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.51 {
+		iface MIXER
+		name 'Analogue Output 02 Playback Enum'
+		value 'Mix B'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.52 {
+		iface MIXER
+		name 'Analogue Output 03 Playback Enum'
+		value 'PCM 3'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.53 {
+		iface MIXER
+		name 'Analogue Output 04 Playback Enum'
+		value 'PCM 4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.54 {
+		iface MIXER
+		name 'Analogue Output 05 Playback Enum'
+		value 'PCM 5'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.55 {
+		iface MIXER
+		name 'Analogue Output 06 Playback Enum'
+		value 'PCM 6'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.56 {
+		iface MIXER
+		name 'Analogue Output 07 Playback Enum'
+		value 'Mix A'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.57 {
+		iface MIXER
+		name 'Analogue Output 08 Playback Enum'
+		value 'Mix B'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.58 {
+		iface MIXER
+		name 'Analogue Output 09 Playback Enum'
+		value 'Mix A'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.59 {
+		iface MIXER
+		name 'Analogue Output 10 Playback Enum'
+		value 'Mix B'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.60 {
+		iface MIXER
+		name 'S/PDIF Output 1 Playback Enum'
+		value 'Analogue 3'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.61 {
+		iface MIXER
+		name 'S/PDIF Output 2 Playback Enum'
+		value 'Analogue 4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.62 {
+		iface MIXER
+		name 'ADAT Output 1 Playback Enum'
+		value 'PCM 13'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.63 {
+		iface MIXER
+		name 'ADAT Output 2 Playback Enum'
+		value 'PCM 14'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.64 {
+		iface MIXER
+		name 'ADAT Output 3 Playback Enum'
+		value 'PCM 15'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.65 {
+		iface MIXER
+		name 'ADAT Output 4 Playback Enum'
+		value 'PCM 16'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.66 {
+		iface MIXER
+		name 'ADAT Output 5 Playback Enum'
+		value 'PCM 17'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.67 {
+		iface MIXER
+		name 'ADAT Output 6 Playback Enum'
+		value 'PCM 18'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.68 {
+		iface MIXER
+		name 'ADAT Output 7 Playback Enum'
+		value 'PCM 19'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.69 {
+		iface MIXER
+		name 'ADAT Output 8 Playback Enum'
+		value 'PCM 20'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.70 {
+		iface MIXER
+		name 'Mixer Input 01 Capture Enum'
+		value 'S/PDIF 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.71 {
+		iface MIXER
+		name 'Mixer Input 02 Capture Enum'
+		value 'S/PDIF 2'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.72 {
+		iface MIXER
+		name 'Mixer Input 03 Capture Enum'
+		value 'PCM 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.73 {
+		iface MIXER
+		name 'Mixer Input 04 Capture Enum'
+		value 'PCM 2'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.74 {
+		iface MIXER
+		name 'Mixer Input 05 Capture Enum'
+		value 'Analogue 5'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.75 {
+		iface MIXER
+		name 'Mixer Input 06 Capture Enum'
+		value 'Analogue 6'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.76 {
+		iface MIXER
+		name 'Mixer Input 07 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.77 {
+		iface MIXER
+		name 'Mixer Input 08 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.78 {
+		iface MIXER
+		name 'Mixer Input 09 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.79 {
+		iface MIXER
+		name 'Mixer Input 10 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.80 {
+		iface MIXER
+		name 'Mixer Input 11 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.81 {
+		iface MIXER
+		name 'Mixer Input 12 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.82 {
+		iface MIXER
+		name 'Mixer Input 13 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.83 {
+		iface MIXER
+		name 'Mixer Input 14 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.84 {
+		iface MIXER
+		name 'Mixer Input 15 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.85 {
+		iface MIXER
+		name 'Mixer Input 16 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.86 {
+		iface MIXER
+		name 'Mixer Input 17 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.87 {
+		iface MIXER
+		name 'Mixer Input 18 Capture Enum'
+		value Off
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.88 {
+		iface MIXER
+		name 'PCM 01 Capture Enum'
+		value 'Analogue 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.89 {
+		iface MIXER
+		name 'PCM 02 Capture Enum'
+		value 'Analogue 2'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.90 {
+		iface MIXER
+		name 'PCM 03 Capture Enum'
+		value 'Analogue 3'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.91 {
+		iface MIXER
+		name 'PCM 04 Capture Enum'
+		value 'Analogue 4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.92 {
+		iface MIXER
+		name 'PCM 05 Capture Enum'
+		value 'Analogue 5'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.93 {
+		iface MIXER
+		name 'PCM 06 Capture Enum'
+		value 'Analogue 6'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.94 {
+		iface MIXER
+		name 'PCM 07 Capture Enum'
+		value 'Analogue 7'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.95 {
+		iface MIXER
+		name 'PCM 08 Capture Enum'
+		value 'Analogue 8'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.96 {
+		iface MIXER
+		name 'PCM 09 Capture Enum'
+		value 'S/PDIF 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.97 {
+		iface MIXER
+		name 'PCM 10 Capture Enum'
+		value 'S/PDIF 2'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.98 {
+		iface MIXER
+		name 'PCM 11 Capture Enum'
+		value 'ADAT 1'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.99 {
+		iface MIXER
+		name 'PCM 12 Capture Enum'
+		value 'ADAT 2'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.100 {
+		iface MIXER
+		name 'PCM 13 Capture Enum'
+		value 'ADAT 3'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.101 {
+		iface MIXER
+		name 'PCM 14 Capture Enum'
+		value 'ADAT 4'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.102 {
+		iface MIXER
+		name 'PCM 15 Capture Enum'
+		value 'ADAT 5'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.103 {
+		iface MIXER
+		name 'PCM 16 Capture Enum'
+		value 'ADAT 6'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.104 {
+		iface MIXER
+		name 'PCM 17 Capture Enum'
+		value 'ADAT 7'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.105 {
+		iface MIXER
+		name 'PCM 18 Capture Enum'
+		value 'ADAT 8'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 Off
+			item.1 'Analogue 1'
+			item.2 'Analogue 2'
+			item.3 'Analogue 3'
+			item.4 'Analogue 4'
+			item.5 'Analogue 5'
+			item.6 'Analogue 6'
+			item.7 'Analogue 7'
+			item.8 'Analogue 8'
+			item.9 'S/PDIF 1'
+			item.10 'S/PDIF 2'
+			item.11 'ADAT 1'
+			item.12 'ADAT 2'
+			item.13 'ADAT 3'
+			item.14 'ADAT 4'
+			item.15 'ADAT 5'
+			item.16 'ADAT 6'
+			item.17 'ADAT 7'
+			item.18 'ADAT 8'
+			item.19 'Mix A'
+			item.20 'Mix B'
+			item.21 'Mix C'
+			item.22 'Mix D'
+			item.23 'Mix E'
+			item.24 'Mix F'
+			item.25 'Mix G'
+			item.26 'Mix H'
+			item.27 'Mix I'
+			item.28 'Mix J'
+			item.29 'PCM 1'
+			item.30 'PCM 2'
+			item.31 'PCM 3'
+			item.32 'PCM 4'
+			item.33 'PCM 5'
+			item.34 'PCM 6'
+			item.35 'PCM 7'
+			item.36 'PCM 8'
+			item.37 'PCM 9'
+			item.38 'PCM 10'
+			item.39 'PCM 11'
+			item.40 'PCM 12'
+			item.41 'PCM 13'
+			item.42 'PCM 14'
+			item.43 'PCM 15'
+			item.44 'PCM 16'
+			item.45 'PCM 17'
+			item.46 'PCM 18'
+			item.47 'PCM 19'
+			item.48 'PCM 20'
+		}
+	}
+	control.106 {
+		iface MIXER
+		name 'Mix A Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.107 {
+		iface MIXER
+		name 'Mix A Input 02 Playback Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -8000
+		}
+	}
+	control.108 {
+		iface MIXER
+		name 'Mix A Input 03 Playback Volume'
+		value 154
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -300
+		}
+	}
+	control.109 {
+		iface MIXER
+		name 'Mix A Input 04 Playback Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -8000
+		}
+	}
+	control.110 {
+		iface MIXER
+		name 'Mix A Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.111 {
+		iface MIXER
+		name 'Mix A Input 06 Playback Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -8000
+		}
+	}
+	control.112 {
+		iface MIXER
+		name 'Mix A Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.113 {
+		iface MIXER
+		name 'Mix A Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.114 {
+		iface MIXER
+		name 'Mix A Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.115 {
+		iface MIXER
+		name 'Mix A Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.116 {
+		iface MIXER
+		name 'Mix A Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.117 {
+		iface MIXER
+		name 'Mix A Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.118 {
+		iface MIXER
+		name 'Mix A Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.119 {
+		iface MIXER
+		name 'Mix A Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.120 {
+		iface MIXER
+		name 'Mix A Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.121 {
+		iface MIXER
+		name 'Mix A Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.122 {
+		iface MIXER
+		name 'Mix A Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.123 {
+		iface MIXER
+		name 'Mix A Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.124 {
+		iface MIXER
+		name 'Mix B Input 01 Playback Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -8000
+		}
+	}
+	control.125 {
+		iface MIXER
+		name 'Mix B Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.126 {
+		iface MIXER
+		name 'Mix B Input 03 Playback Volume'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -8000
+		}
+	}
+	control.127 {
+		iface MIXER
+		name 'Mix B Input 04 Playback Volume'
+		value 154
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -300
+		}
+	}
+	control.128 {
+		iface MIXER
+		name 'Mix B Input 05 Playback Volume'
+		value 1
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -7950
+		}
+	}
+	control.129 {
+		iface MIXER
+		name 'Mix B Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.130 {
+		iface MIXER
+		name 'Mix B Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.131 {
+		iface MIXER
+		name 'Mix B Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.132 {
+		iface MIXER
+		name 'Mix B Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.133 {
+		iface MIXER
+		name 'Mix B Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.134 {
+		iface MIXER
+		name 'Mix B Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.135 {
+		iface MIXER
+		name 'Mix B Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.136 {
+		iface MIXER
+		name 'Mix B Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.137 {
+		iface MIXER
+		name 'Mix B Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.138 {
+		iface MIXER
+		name 'Mix B Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.139 {
+		iface MIXER
+		name 'Mix B Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.140 {
+		iface MIXER
+		name 'Mix B Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.141 {
+		iface MIXER
+		name 'Mix B Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.142 {
+		iface MIXER
+		name 'Mix C Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.143 {
+		iface MIXER
+		name 'Mix C Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.144 {
+		iface MIXER
+		name 'Mix C Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.145 {
+		iface MIXER
+		name 'Mix C Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.146 {
+		iface MIXER
+		name 'Mix C Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.147 {
+		iface MIXER
+		name 'Mix C Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.148 {
+		iface MIXER
+		name 'Mix C Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.149 {
+		iface MIXER
+		name 'Mix C Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.150 {
+		iface MIXER
+		name 'Mix C Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.151 {
+		iface MIXER
+		name 'Mix C Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.152 {
+		iface MIXER
+		name 'Mix C Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.153 {
+		iface MIXER
+		name 'Mix C Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.154 {
+		iface MIXER
+		name 'Mix C Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.155 {
+		iface MIXER
+		name 'Mix C Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.156 {
+		iface MIXER
+		name 'Mix C Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.157 {
+		iface MIXER
+		name 'Mix C Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.158 {
+		iface MIXER
+		name 'Mix C Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.159 {
+		iface MIXER
+		name 'Mix C Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.160 {
+		iface MIXER
+		name 'Mix D Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.161 {
+		iface MIXER
+		name 'Mix D Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.162 {
+		iface MIXER
+		name 'Mix D Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.163 {
+		iface MIXER
+		name 'Mix D Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.164 {
+		iface MIXER
+		name 'Mix D Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.165 {
+		iface MIXER
+		name 'Mix D Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.166 {
+		iface MIXER
+		name 'Mix D Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.167 {
+		iface MIXER
+		name 'Mix D Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.168 {
+		iface MIXER
+		name 'Mix D Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.169 {
+		iface MIXER
+		name 'Mix D Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.170 {
+		iface MIXER
+		name 'Mix D Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.171 {
+		iface MIXER
+		name 'Mix D Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.172 {
+		iface MIXER
+		name 'Mix D Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.173 {
+		iface MIXER
+		name 'Mix D Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.174 {
+		iface MIXER
+		name 'Mix D Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.175 {
+		iface MIXER
+		name 'Mix D Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.176 {
+		iface MIXER
+		name 'Mix D Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.177 {
+		iface MIXER
+		name 'Mix D Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.178 {
+		iface MIXER
+		name 'Mix E Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.179 {
+		iface MIXER
+		name 'Mix E Input 02 Playback Volume'
+		value 159
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 -50
+		}
+	}
+	control.180 {
+		iface MIXER
+		name 'Mix E Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.181 {
+		iface MIXER
+		name 'Mix E Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.182 {
+		iface MIXER
+		name 'Mix E Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.183 {
+		iface MIXER
+		name 'Mix E Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.184 {
+		iface MIXER
+		name 'Mix E Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.185 {
+		iface MIXER
+		name 'Mix E Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.186 {
+		iface MIXER
+		name 'Mix E Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.187 {
+		iface MIXER
+		name 'Mix E Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.188 {
+		iface MIXER
+		name 'Mix E Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.189 {
+		iface MIXER
+		name 'Mix E Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.190 {
+		iface MIXER
+		name 'Mix E Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.191 {
+		iface MIXER
+		name 'Mix E Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.192 {
+		iface MIXER
+		name 'Mix E Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.193 {
+		iface MIXER
+		name 'Mix E Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.194 {
+		iface MIXER
+		name 'Mix E Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.195 {
+		iface MIXER
+		name 'Mix E Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.196 {
+		iface MIXER
+		name 'Mix F Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.197 {
+		iface MIXER
+		name 'Mix F Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.198 {
+		iface MIXER
+		name 'Mix F Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.199 {
+		iface MIXER
+		name 'Mix F Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.200 {
+		iface MIXER
+		name 'Mix F Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.201 {
+		iface MIXER
+		name 'Mix F Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.202 {
+		iface MIXER
+		name 'Mix F Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.203 {
+		iface MIXER
+		name 'Mix F Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.204 {
+		iface MIXER
+		name 'Mix F Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.205 {
+		iface MIXER
+		name 'Mix F Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.206 {
+		iface MIXER
+		name 'Mix F Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.207 {
+		iface MIXER
+		name 'Mix F Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.208 {
+		iface MIXER
+		name 'Mix F Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.209 {
+		iface MIXER
+		name 'Mix F Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.210 {
+		iface MIXER
+		name 'Mix F Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.211 {
+		iface MIXER
+		name 'Mix F Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.212 {
+		iface MIXER
+		name 'Mix F Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.213 {
+		iface MIXER
+		name 'Mix F Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.214 {
+		iface MIXER
+		name 'Mix G Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.215 {
+		iface MIXER
+		name 'Mix G Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.216 {
+		iface MIXER
+		name 'Mix G Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.217 {
+		iface MIXER
+		name 'Mix G Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.218 {
+		iface MIXER
+		name 'Mix G Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.219 {
+		iface MIXER
+		name 'Mix G Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.220 {
+		iface MIXER
+		name 'Mix G Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.221 {
+		iface MIXER
+		name 'Mix G Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.222 {
+		iface MIXER
+		name 'Mix G Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.223 {
+		iface MIXER
+		name 'Mix G Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.224 {
+		iface MIXER
+		name 'Mix G Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.225 {
+		iface MIXER
+		name 'Mix G Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.226 {
+		iface MIXER
+		name 'Mix G Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.227 {
+		iface MIXER
+		name 'Mix G Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.228 {
+		iface MIXER
+		name 'Mix G Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.229 {
+		iface MIXER
+		name 'Mix G Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.230 {
+		iface MIXER
+		name 'Mix G Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.231 {
+		iface MIXER
+		name 'Mix G Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.232 {
+		iface MIXER
+		name 'Mix H Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.233 {
+		iface MIXER
+		name 'Mix H Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.234 {
+		iface MIXER
+		name 'Mix H Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.235 {
+		iface MIXER
+		name 'Mix H Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.236 {
+		iface MIXER
+		name 'Mix H Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.237 {
+		iface MIXER
+		name 'Mix H Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.238 {
+		iface MIXER
+		name 'Mix H Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.239 {
+		iface MIXER
+		name 'Mix H Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.240 {
+		iface MIXER
+		name 'Mix H Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.241 {
+		iface MIXER
+		name 'Mix H Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.242 {
+		iface MIXER
+		name 'Mix H Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.243 {
+		iface MIXER
+		name 'Mix H Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.244 {
+		iface MIXER
+		name 'Mix H Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.245 {
+		iface MIXER
+		name 'Mix H Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.246 {
+		iface MIXER
+		name 'Mix H Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.247 {
+		iface MIXER
+		name 'Mix H Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.248 {
+		iface MIXER
+		name 'Mix H Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.249 {
+		iface MIXER
+		name 'Mix H Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.250 {
+		iface MIXER
+		name 'Mix I Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.251 {
+		iface MIXER
+		name 'Mix I Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.252 {
+		iface MIXER
+		name 'Mix I Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.253 {
+		iface MIXER
+		name 'Mix I Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.254 {
+		iface MIXER
+		name 'Mix I Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.255 {
+		iface MIXER
+		name 'Mix I Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.256 {
+		iface MIXER
+		name 'Mix I Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.257 {
+		iface MIXER
+		name 'Mix I Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.258 {
+		iface MIXER
+		name 'Mix I Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.259 {
+		iface MIXER
+		name 'Mix I Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.260 {
+		iface MIXER
+		name 'Mix I Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.261 {
+		iface MIXER
+		name 'Mix I Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.262 {
+		iface MIXER
+		name 'Mix I Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.263 {
+		iface MIXER
+		name 'Mix I Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.264 {
+		iface MIXER
+		name 'Mix I Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.265 {
+		iface MIXER
+		name 'Mix I Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.266 {
+		iface MIXER
+		name 'Mix I Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.267 {
+		iface MIXER
+		name 'Mix I Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.268 {
+		iface MIXER
+		name 'Mix J Input 01 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.269 {
+		iface MIXER
+		name 'Mix J Input 02 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.270 {
+		iface MIXER
+		name 'Mix J Input 03 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.271 {
+		iface MIXER
+		name 'Mix J Input 04 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.272 {
+		iface MIXER
+		name 'Mix J Input 05 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.273 {
+		iface MIXER
+		name 'Mix J Input 06 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.274 {
+		iface MIXER
+		name 'Mix J Input 07 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.275 {
+		iface MIXER
+		name 'Mix J Input 08 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.276 {
+		iface MIXER
+		name 'Mix J Input 09 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.277 {
+		iface MIXER
+		name 'Mix J Input 10 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.278 {
+		iface MIXER
+		name 'Mix J Input 11 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.279 {
+		iface MIXER
+		name 'Mix J Input 12 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.280 {
+		iface MIXER
+		name 'Mix J Input 13 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.281 {
+		iface MIXER
+		name 'Mix J Input 14 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.282 {
+		iface MIXER
+		name 'Mix J Input 15 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.283 {
+		iface MIXER
+		name 'Mix J Input 16 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.284 {
+		iface MIXER
+		name 'Mix J Input 17 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.285 {
+		iface MIXER
+		name 'Mix J Input 18 Playback Volume'
+		value 160
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 184 (step 1)'
+			dbmin -8000
+			dbmax 1200
+			dbvalue.0 0
+		}
+	}
+	control.286 {
+		iface PCM
+		name 'Level Meter'
+		value.0 255
+		value.1 262
+		value.2 0
+		value.3 0
+		value.4 0
+		value.5 0
+		value.6 255
+		value.7 262
+		value.8 255
+		value.9 262
+		value.10 0
+		value.11 0
+		value.12 0
+		value.13 0
+		value.14 0
+		value.15 0
+		value.16 0
+		value.17 0
+		value.18 0
+		value.19 0
+		value.20 255
+		value.21 262
+		value.22 0
+		value.23 0
+		value.24 0
+		value.25 0
+		value.26 0
+		value.27 0
+		value.28 0
+		value.29 0
+		value.30 0
+		value.31 0
+		value.32 0
+		value.33 0
+		value.34 0
+		value.35 0
+		value.36 0
+		value.37 0
+		value.38 0
+		value.39 0
+		value.40 0
+		value.41 0
+		value.42 0
+		value.43 0
+		value.44 0
+		value.45 0
+		value.46 255
+		value.47 262
+		value.48 0
+		value.49 0
+		value.50 0
+		value.51 0
+		value.52 0
+		value.53 0
+		value.54 0
+		value.55 0
+		comment {
+			access 'read volatile'
+			type INTEGER
+			count 56
+			range '0 - 4095 (step 1)'
+		}
+	}
+	control.287 {
+		iface MIXER
+		name 'Sync Status'
+		value Locked
+		comment {
+			access read
+			type ENUMERATED
+			count 1
+			item.0 Unlocked
+			item.1 Locked
+		}
+	}
+	control.288 {
+		iface MIXER
+		name 'Standalone Switch'
+		value true
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.289 {
+		iface MIXER
+		name 'S/PDIF Source Capture Enum'
+		value Optical
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 None
+			item.1 Optical
+			item.2 RCA
+		}
+	}
+}

--- a/src/iface-mixer.c
+++ b/src/iface-mixer.c
@@ -146,6 +146,38 @@ static void add_sample_rate_control(
   gtk_box_append(GTK_BOX(b), w);
 }
 
+/* Scarlett 18i20 3rd Gen
+ * Scarlett 16i16, 18i16, and 18i20 4th Gen
+ * Clarett 4Pre and 8Pre */
+static void add_spdif_source_control(
+  struct alsa_card *card,
+  GtkWidget        *global_controls
+) {
+  GArray *elems = card->elems;
+
+  struct alsa_elem *spdif_source = get_elem_by_name(elems, "S/PDIF Source Capture Enum");
+  if (!spdif_source) {
+    return;
+  }
+
+  GtkWidget *b = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
+  gtk_widget_set_tooltip_text(
+    b,
+    "S/PDIF Source determines if S/PDIF channels are sourced "
+    "by RCA or Optical (TOSLINK) ports.\n\n"
+    "Note that Optical renders ADAT channels unusable."
+  );
+  gtk_box_append(GTK_BOX(global_controls), b);
+
+  GtkWidget *l = gtk_label_new("S/PDIF Source");
+  GtkWidget *w = make_drop_down_alsa_elem(spdif_source, NULL);
+  gtk_widget_add_css_class(w, "spdif-source");
+  gtk_widget_add_css_class(w, "fixed");
+
+  gtk_box_append(GTK_BOX(b), l);
+  gtk_box_append(GTK_BOX(b), w);
+}
+
 static void add_speaker_switching_controls_enum(
   struct alsa_card *card,
   GtkWidget        *global_controls
@@ -931,6 +963,7 @@ static void create_global_controls(
   add_sync_status_control(card, column[1]);
   add_power_status_control(card, column[1]);
   add_sample_rate_control(card, column[2]);
+  add_spdif_source_control(card, column[2]);
   add_speaker_switching_controls_enum(card, column[0]);
   add_speaker_switching_controls_switches(card, column[0]);
   add_talkback_controls_enum(card, column[1]);


### PR DESCRIPTION
Added a "S/PDIF Source" drop-down control to the collection of Global controls to complete #186. 

Also added a new (and up-to-date) ALSA state file for the Clarett 8Pre USB, as the repo doesn't currently contain one for the device. Also, the `.state` files in the `demo` directory were originally uploaded _before_ the `S/PDIF Source Capture Enum` control was added to ALSA, so they can't be used to test the functionality contained in this PR.