### PR TITLE
Enhancement: stereo mixes

### DIFF
--- a/src/gtkdial.c
+++ b/src/gtkdial.c
@@ -921,28 +921,35 @@ static void draw_slider(
 }
 
 static void draw_origin_indicator(GtkDial *dial, cairo_t *cr) {
-  double halo = dial->slider_thickness * 0.8;
+  double track_thickness = dial->slider_thickness * 0.35;
 
-  if (halo < 2.0)
-    halo = 2.0;
+  if (track_thickness < 1.5)
+    track_thickness = 1.5;
 
-  double dot_radius = dial->slider_thickness * 0.55;
+  double halo_width = dial->slider_thickness / 2.0;
+
+  if (halo_width < 2.0)
+    halo_width = 2.0;
+
+  double dot_radius = dial->slider_thickness * 0.4;
 
   if (dot_radius < 1.5)
     dot_radius = 1.5;
+
+  double halo_radius = dot_radius + halo_width / 2.0;
 
   double dot_x = dial->slider_cx;
   double dot_y = dial->slider_cy;
 
   // subtle path hint for the circular track
-  cairo_set_line_width(cr, dial->slider_thickness * 0.6);
+  cairo_set_line_width(cr, track_thickness);
   cairo_set_source_rgba_dim(cr, 1, 1, 1, 0.12, dial->dim);
   cairo_arc(cr, dial->cx, dial->cy, dial->slider_radius, ANGLE_START, ANGLE_END);
   cairo_stroke(cr);
 
   // outer halo to give the marker contrast against the knob fill
   cairo_set_source_rgba_dim(cr, 0, 0, 0, 0.35, dial->dim);
-  cairo_arc(cr, dot_x, dot_y, dot_radius + halo * 0.35, 0, 2 * M_PI);
+  cairo_arc(cr, dot_x, dot_y, halo_radius, 0, 2 * M_PI);
   cairo_fill(cr);
 
   cairo_set_source_rgba_dim(cr, 1, 1, 1, 0.9, dial->dim);

--- a/src/gtkdial.c
+++ b/src/gtkdial.c
@@ -921,37 +921,28 @@ static void draw_slider(
 }
 
 static void draw_origin_indicator(GtkDial *dial, cairo_t *cr) {
-  double base = dial->slider_thickness / 3.0;
+  double halo = dial->slider_thickness * 0.8;
 
-  if (base < 2.0)
-    base = 2.0;
+  if (halo < 2.0)
+    halo = 2.0;
 
-  double track_extent = dial->knob_radius - dial->slider_thickness * 0.6;
+  double dot_radius = dial->slider_thickness * 0.55;
 
-  if (track_extent < base)
-    track_extent = base;
+  if (dot_radius < 1.5)
+    dot_radius = 1.5;
 
-  double dot_radius = base * 0.7;
+  double dot_x = dial->slider_cx;
+  double dot_y = dial->slider_cy;
 
-  double lower = gtk_adjustment_get_lower(dial->adj);
-  double upper = gtk_adjustment_get_upper(dial->adj);
-  double fraction = 0.5;
-
-  if (upper > lower)
-    fraction = calc_valp(gtk_dial_get_value(dial), lower, upper);
-
-  double offset = fraction * 2.0 - 1.0;
-  double dot_x = dial->cx + offset * track_extent;
-  double dot_y = dial->cy;
-
-  cairo_set_line_width(cr, base * 0.6);
-  cairo_set_source_rgba_dim(cr, 1, 1, 1, 0.18, dial->dim);
-  cairo_move_to(cr, dial->cx - track_extent, dot_y);
-  cairo_line_to(cr, dial->cx + track_extent, dot_y);
+  // subtle path hint for the circular track
+  cairo_set_line_width(cr, dial->slider_thickness * 0.6);
+  cairo_set_source_rgba_dim(cr, 1, 1, 1, 0.12, dial->dim);
+  cairo_arc(cr, dial->cx, dial->cy, dial->slider_radius, ANGLE_START, ANGLE_END);
   cairo_stroke(cr);
 
+  // outer halo to give the marker contrast against the knob fill
   cairo_set_source_rgba_dim(cr, 0, 0, 0, 0.35, dial->dim);
-  cairo_arc(cr, dot_x, dot_y, dot_radius + base * 0.25, 0, 2 * M_PI);
+  cairo_arc(cr, dot_x, dot_y, dot_radius + halo * 0.35, 0, 2 * M_PI);
   cairo_fill(cr);
 
   cairo_set_source_rgba_dim(cr, 1, 1, 1, 0.9, dial->dim);

--- a/src/gtkdial.c
+++ b/src/gtkdial.c
@@ -926,18 +926,7 @@ static void draw_origin_indicator(GtkDial *dial, cairo_t *cr) {
   if (track_thickness < 1.5)
     track_thickness = 1.5;
 
-  double halo_width = dial->slider_thickness / 2.0;
-
-  if (halo_width < 2.0)
-    halo_width = 2.0;
-
-  double dot_radius = dial->slider_thickness * 0.4;
-
-  if (dot_radius < 1.5)
-    dot_radius = 1.5;
-
-  double halo_radius = dot_radius + halo_width / 2.0;
-  dot_radius = halo_radius;
+  double dot_radius = track_thickness;
 
   double dot_x = dial->slider_cx;
   double dot_y = dial->slider_cy;
@@ -947,11 +936,6 @@ static void draw_origin_indicator(GtkDial *dial, cairo_t *cr) {
   cairo_set_source_rgba_dim(cr, 1, 1, 1, 0.12, dial->dim);
   cairo_arc(cr, dial->cx, dial->cy, dial->slider_radius, ANGLE_START, ANGLE_END);
   cairo_stroke(cr);
-
-  // outer halo to give the marker contrast against the knob fill
-  cairo_set_source_rgba_dim(cr, 0, 0, 0, 0.35, dial->dim);
-  cairo_arc(cr, dot_x, dot_y, halo_radius, 0, 2 * M_PI);
-  cairo_fill(cr);
 
   cairo_set_source_rgba_dim(cr, 1, 1, 1, 0.9, dial->dim);
   cairo_arc(cr, dot_x, dot_y, dot_radius, 0, 2 * M_PI);

--- a/src/gtkdial.c
+++ b/src/gtkdial.c
@@ -1597,10 +1597,18 @@ static void gtk_dial_click_gesture_pressed(
   if (n_press >= 2) {
     double lower = gtk_adjustment_get_lower(dial->adj);
 
-    if (gtk_dial_get_value(dial) != lower)
+    if (gtk_dial_get_has_origin(dial)) {
+      double zero_db = gtk_dial_get_zero_db(dial);
+
+      if (zero_db == -G_MAXDOUBLE)
+        zero_db = lower;
+
+      set_value(dial, zero_db);
+    } else if (gtk_dial_get_value(dial) != lower) {
       set_value(dial, lower);
-    else
+    } else {
       set_value(dial, dial->zero_db);
+    }
 
     return;
   }

--- a/src/gtkdial.c
+++ b/src/gtkdial.c
@@ -94,6 +94,7 @@ enum {
   PROP_IS_LINEAR,
   PROP_TAPER,
   PROP_CAN_CONTROL,
+  PROP_HAS_ORIGIN,
   PROP_PEAK_HOLD,
   LAST_PROP
 };
@@ -123,6 +124,7 @@ struct _GtkDial {
   gboolean is_linear;
   int taper;
   gboolean can_control;
+  gboolean has_origin;
   int peak_hold;
 
   int properties_updated;
@@ -603,6 +605,19 @@ static void gtk_dial_class_init(GtkDialClass *klass) {
   );
 
   /**
+   * GtkDial:has-origin: (attributes org.gtk.Method.get=gtk_dial_get_has_origin org.gtk.Method.set=gtk_dial_set_has_origin)
+   *
+   * Whether the dial should visually emphasize its origin.
+   */
+  properties[PROP_HAS_ORIGIN] = g_param_spec_boolean(
+    "has-origin",
+    "HasOrigin",
+    "Whether the dial should visually emphasize its origin",
+    FALSE,
+    G_PARAM_READWRITE | G_PARAM_CONSTRUCT
+  );
+
+  /**
    * GtkDial:peak-hold: (attributes org.gtk.Method.get=gtk_dial_get_peak_hold org.gtk.Method.set=gtk_dial_set_peak_hold)
    *
    * The number of milliseconds to hold the peak value.
@@ -739,6 +754,7 @@ static void gtk_dial_init(GtkDial *dial) {
   dial->hist_head = 0;
   dial->hist_tail = 0;
   dial->hist_count = 0;
+  dial->has_origin = FALSE;
 }
 
 static void dial_measure(
@@ -1069,6 +1085,9 @@ static void gtk_dial_set_property(
     case PROP_CAN_CONTROL:
       gtk_dial_set_can_control(dial, g_value_get_boolean(value));
       break;
+    case PROP_HAS_ORIGIN:
+      gtk_dial_set_has_origin(dial, g_value_get_boolean(value));
+      break;
     case PROP_PEAK_HOLD:
       gtk_dial_set_peak_hold(dial, g_value_get_int(value));
       break;
@@ -1107,6 +1126,9 @@ static void gtk_dial_get_property(
       break;
     case PROP_CAN_CONTROL:
       g_value_set_boolean(value, dial->can_control);
+      break;
+    case PROP_HAS_ORIGIN:
+      g_value_set_boolean(value, dial->has_origin);
       break;
     case PROP_PEAK_HOLD:
       g_value_set_int(value, dial->peak_hold);
@@ -1214,6 +1236,16 @@ void gtk_dial_set_can_control(GtkDial *dial, gboolean can_control) {
 
 gboolean gtk_dial_get_can_control(GtkDial *dial) {
   return dial->can_control;
+}
+
+void gtk_dial_set_has_origin(GtkDial *dial, gboolean has_origin) {
+  dial->has_origin = has_origin;
+  dial->properties_updated = 1;
+  gtk_widget_queue_draw(GTK_WIDGET(dial));
+}
+
+gboolean gtk_dial_get_has_origin(GtkDial *dial) {
+  return dial->has_origin;
 }
 
 void gtk_dial_set_level_meter_colours(

--- a/src/gtkdial.c
+++ b/src/gtkdial.c
@@ -937,6 +937,7 @@ static void draw_origin_indicator(GtkDial *dial, cairo_t *cr) {
     dot_radius = 1.5;
 
   double halo_radius = dot_radius + halo_width / 2.0;
+  dot_radius = halo_radius;
 
   double dot_x = dial->slider_cx;
   double dot_y = dial->slider_cy;

--- a/src/window-mixer.c
+++ b/src/window-mixer.c
@@ -4,6 +4,7 @@
 #include <gtk/gtk.h>
 #include <math.h>
 
+#include "gtkdial.h"
 #include "gtkhelper.h"
 #include "db.h"
 #include "stringhelper.h"

--- a/src/window-mixer.c
+++ b/src/window-mixer.c
@@ -483,6 +483,7 @@ static void mixer_combined_create_widgets(struct mixer_combined_cell *cell) {
   );
   gtk_widget_set_vexpand(cell->pan_dial, TRUE);
   gtk_dial_set_has_origin(GTK_DIAL(cell->pan_dial), TRUE);
+  gtk_dial_set_zero_db(GTK_DIAL(cell->pan_dial), 0.0);
   gtk_dial_set_can_control(GTK_DIAL(cell->pan_dial), TRUE);
   gtk_dial_set_round_digits(GTK_DIAL(cell->pan_dial), 0);
 

--- a/src/window-mixer.c
+++ b/src/window-mixer.c
@@ -2,11 +2,79 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include <gtk/gtk.h>
+#include <math.h>
 
 #include "gtkhelper.h"
+#include "db.h"
 #include "stringhelper.h"
 #include "widget-gain.h"
 #include "window-mixer.h"
+
+#define STACK_PAGE_SPLIT    "split"
+#define STACK_PAGE_COMBINED "combined"
+#define MIXER_PAN_RANGE     100.0
+
+struct mixer_state;
+struct mixer_pair;
+
+struct mixer_combined_cell {
+  struct mixer_pair *pair;
+  struct alsa_elem  *left_elem;
+  struct alsa_elem  *right_elem;
+  GtkStack          *left_stack;
+  GtkStack          *right_stack;
+  GtkWidget         *left_widget;
+  GtkWidget         *right_widget;
+  GtkWidget         *volume_box;
+  GtkWidget         *volume_dial;
+  GtkWidget         *volume_label;
+  GtkWidget         *pan_box;
+  GtkWidget         *pan_dial;
+  GtkWidget         *pan_label;
+  int                min_val;
+  int                max_val;
+  int                min_cdB;
+  int                max_cdB;
+  int                min_db;
+  int                max_db;
+  int                zero_is_off;
+  double             scale;
+  double             volume_norm;
+  double             pan_norm;
+  gboolean           has_combined;
+  gboolean           updating;
+  gboolean           is_linear;
+};
+
+struct mixer_pair {
+  struct mixer_state *state;
+  int                 pair_index;
+  int                 left_mix;
+  int                 right_mix;
+  GtkWidget          *toggle_box;
+  GtkSwitch          *toggle_switch;
+  GtkWidget          *toggle_label;
+  gboolean            combined;
+  struct mixer_combined_cell cells[MAX_MIX_OUT];
+};
+
+struct mixer_state {
+  struct alsa_card *card;
+  GtkWidget        *top;
+  GtkWidget        *mixer_top;
+  int               mix_count;
+  int               input_count;
+  int               pair_count;
+  GtkWidget        *mix_labels_left[MAX_MIX_OUT];
+  GtkWidget        *mix_labels_right[MAX_MIX_OUT];
+  GtkWidget        *stacks[MAX_MIX_OUT][MAX_MIX_OUT];
+  GtkWidget        *gain_widgets[MAX_MIX_OUT][MAX_MIX_OUT];
+  struct alsa_elem *elems[MAX_MIX_OUT][MAX_MIX_OUT];
+  struct mixer_pair pairs[MAX_MIX_OUT / 2];
+};
+
+static void mixer_pair_set_combined(struct mixer_pair *pair, gboolean combined);
+static void mixer_combined_sync(struct mixer_combined_cell *cell);
 
 static void mixer_gain_enter(
   GtkEventControllerMotion *controller,
@@ -56,6 +124,565 @@ static void add_mixer_hover_controller(GtkWidget *widget) {
   gtk_widget_add_controller(widget, motion);
 }
 
+static double mixer_value_to_norm(const struct mixer_combined_cell *cell, int value) {
+  if (cell->max_val == cell->min_val)
+    return 0.0;
+
+  double norm =
+    (double)(value - cell->min_val) /
+    (double)(cell->max_val - cell->min_val);
+
+  if (norm < 0.0)
+    norm = 0.0;
+  else if (norm > 1.0)
+    norm = 1.0;
+
+  return norm;
+}
+
+static int mixer_norm_to_value(const struct mixer_combined_cell *cell, double norm) {
+  if (norm < 0.0)
+    norm = 0.0;
+  else if (norm > 1.0)
+    norm = 1.0;
+
+  double value =
+    norm * (double)(cell->max_val - cell->min_val) + cell->min_val;
+
+  int result = (int)round(value);
+
+  if (result < cell->min_val)
+    result = cell->min_val;
+  else if (result > cell->max_val)
+    result = cell->max_val;
+
+  return result;
+}
+
+static void mixer_combined_update_volume_label(
+  struct mixer_combined_cell *cell,
+  int                         alsa_value
+) {
+  if (!cell->volume_label)
+    return;
+
+  char s[20];
+  char *p = s;
+  double value;
+
+  if (cell->is_linear) {
+    value = linear_value_to_db(
+      alsa_value,
+      cell->min_val,
+      cell->max_val,
+      cell->min_db,
+      cell->max_db
+    );
+  } else {
+    value =
+      ((double)(alsa_value - cell->min_val)) * cell->scale +
+      ((double)cell->min_cdB / 100.0);
+
+    if (value > cell->max_db)
+      value = cell->max_db;
+    else if (value < cell->min_db)
+      value = cell->min_db;
+  }
+
+  if (cell->zero_is_off && fabs(value - cell->min_db) < 0.0001) {
+    p += sprintf(p, "−∞");
+  } else {
+    if (cell->scale <= 0.5)
+      value = round(value * 10) / 10;
+
+    if (value < 0)
+      p += sprintf(p, "−");
+    else if (value > 0)
+      p += sprintf(p, "+");
+
+    if (cell->scale <= 0.5)
+      p += snprintf(p, sizeof(s) - (p - s), "%.1f", fabs(value));
+    else
+      p += snprintf(p, sizeof(s) - (p - s), "%.0f", fabs(value));
+
+    if (cell->scale > 0.5)
+      p += sprintf(p, "dB");
+  }
+
+  gtk_label_set_text(GTK_LABEL(cell->volume_label), s);
+}
+
+static void mixer_combined_update_pan_label(struct mixer_combined_cell *cell) {
+  if (!cell->pan_label)
+    return;
+
+  char s[20];
+  double pan = cell->pan_norm;
+
+  if (fabs(pan) < 0.01) {
+    strcpy(s, "C");
+  } else if (pan < 0) {
+    int percent = (int)round(fabs(pan) * 100.0);
+    snprintf(s, sizeof(s), "L%d", percent);
+  } else {
+    int percent = (int)round(pan * 100.0);
+    snprintf(s, sizeof(s), "R%d", percent);
+  }
+
+  gtk_label_set_text(GTK_LABEL(cell->pan_label), s);
+}
+
+static void mixer_combined_sync(struct mixer_combined_cell *cell) {
+  if (!cell->left_elem || !cell->right_elem)
+    return;
+
+  int left_value = alsa_get_elem_value(cell->left_elem);
+  int right_value = alsa_get_elem_value(cell->right_elem);
+
+  double left_norm = mixer_value_to_norm(cell, left_value);
+  double right_norm = mixer_value_to_norm(cell, right_value);
+  double volume_norm = MAX(left_norm, right_norm);
+
+  if (volume_norm < 0.0001) {
+    volume_norm = 0.0;
+    cell->pan_norm = 0.0;
+  } else {
+    double pan = (right_norm - left_norm) / volume_norm;
+    if (pan < -1.0)
+      pan = -1.0;
+    else if (pan > 1.0)
+      pan = 1.0;
+    cell->pan_norm = pan;
+  }
+
+  cell->volume_norm = volume_norm;
+
+  if (cell->volume_dial) {
+    cell->updating = TRUE;
+    double volume_value =
+      cell->min_val + volume_norm * (cell->max_val - cell->min_val);
+    gtk_dial_set_value(GTK_DIAL(cell->volume_dial), volume_value);
+    mixer_combined_update_volume_label(cell, (int)round(volume_value));
+    cell->updating = FALSE;
+  }
+
+  if (cell->pan_dial) {
+    cell->updating = TRUE;
+    gtk_dial_set_value(
+      GTK_DIAL(cell->pan_dial),
+      cell->pan_norm * MIXER_PAN_RANGE
+    );
+    mixer_combined_update_pan_label(cell);
+    cell->updating = FALSE;
+  }
+}
+
+static void mixer_combined_elem_updated(
+  struct alsa_elem        *elem,
+  void                    *user_data
+) {
+  struct mixer_combined_cell *cell = user_data;
+
+  if (!cell->has_combined || cell->updating)
+    return;
+
+  mixer_combined_sync(cell);
+}
+
+static void mixer_combined_volume_changed(
+  GtkWidget *widget,
+  gpointer   user_data
+) {
+  struct mixer_combined_cell *cell = user_data;
+
+  if (cell->updating)
+    return;
+
+  double dial_value = gtk_dial_get_value(GTK_DIAL(cell->volume_dial));
+  int alsa_value = (int)round(dial_value);
+  double volume_norm = mixer_value_to_norm(cell, alsa_value);
+
+  cell->volume_norm = volume_norm;
+
+  double pan = cell->pan_norm;
+  double left_norm = volume_norm;
+  double right_norm = volume_norm;
+
+  if (pan > 0)
+    left_norm *= 1.0 - pan;
+  else if (pan < 0)
+    right_norm *= 1.0 + pan;
+
+  int left_value = mixer_norm_to_value(cell, left_norm);
+  int right_value = mixer_norm_to_value(cell, right_norm);
+
+  cell->updating = TRUE;
+  alsa_set_elem_value(cell->left_elem, left_value);
+  alsa_set_elem_value(cell->right_elem, right_value);
+  mixer_combined_update_volume_label(cell, alsa_value);
+  cell->updating = FALSE;
+}
+
+static void mixer_combined_pan_changed(
+  GtkWidget *widget,
+  gpointer   user_data
+) {
+  struct mixer_combined_cell *cell = user_data;
+
+  if (cell->updating)
+    return;
+
+  double dial_value = gtk_dial_get_value(GTK_DIAL(cell->pan_dial));
+  double pan_norm = dial_value / MIXER_PAN_RANGE;
+
+  if (pan_norm < -1.0)
+    pan_norm = -1.0;
+  else if (pan_norm > 1.0)
+    pan_norm = 1.0;
+
+  cell->pan_norm = pan_norm;
+
+  double left_norm = cell->volume_norm;
+  double right_norm = cell->volume_norm;
+
+  if (pan_norm > 0)
+    left_norm *= 1.0 - pan_norm;
+  else if (pan_norm < 0)
+    right_norm *= 1.0 + pan_norm;
+
+  int left_value = mixer_norm_to_value(cell, left_norm);
+  int right_value = mixer_norm_to_value(cell, right_norm);
+
+  cell->updating = TRUE;
+  alsa_set_elem_value(cell->left_elem, left_value);
+  alsa_set_elem_value(cell->right_elem, right_value);
+  mixer_combined_update_pan_label(cell);
+  mixer_combined_update_volume_label(
+    cell,
+    (int)round(gtk_dial_get_value(GTK_DIAL(cell->volume_dial)))
+  );
+  cell->updating = FALSE;
+}
+
+static void mixer_combined_create_widgets(struct mixer_combined_cell *cell) {
+  if (!cell->left_stack || !cell->right_stack)
+    return;
+
+  cell->min_val = cell->left_elem->min_val;
+  cell->max_val = cell->left_elem->max_val;
+  cell->min_cdB = cell->left_elem->min_cdB;
+  cell->max_cdB = cell->left_elem->max_cdB;
+  cell->min_db = round(cell->min_cdB / 100.0);
+  cell->max_db = round(cell->max_cdB / 100.0);
+  cell->zero_is_off = 1;
+  cell->is_linear =
+    cell->left_elem->dB_type == SND_CTL_TLVT_DB_LINEAR;
+
+  double step;
+
+  if (cell->is_linear) {
+    cell->scale = 0.5;
+    step = 0.5;
+  } else {
+    cell->scale =
+      (double)(cell->max_cdB - cell->min_cdB) / 100.0 /
+      (cell->max_val - cell->min_val);
+    step = 1.0;
+  }
+
+  cell->volume_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_widget_set_hexpand(cell->volume_box, TRUE);
+  gtk_widget_set_vexpand(cell->volume_box, TRUE);
+
+  cell->volume_dial = gtk_dial_new_with_range(
+    cell->min_val,
+    cell->max_val,
+    step,
+    3 / cell->scale
+  );
+  gtk_widget_set_vexpand(cell->volume_dial, TRUE);
+  gtk_dial_set_is_linear(GTK_DIAL(cell->volume_dial), cell->is_linear);
+  gtk_dial_set_taper(GTK_DIAL(cell->volume_dial), GTK_DIAL_TAPER_LOG);
+
+  int zero_db_value;
+
+  if (cell->is_linear) {
+    zero_db_value = cdb_to_linear_value(
+      0,
+      cell->min_val,
+      cell->max_val,
+      cell->min_cdB,
+      cell->max_cdB
+    );
+  } else {
+    zero_db_value =
+      (int)((0 - cell->min_cdB) / 100.0 / cell->scale + cell->min_val);
+  }
+
+  gtk_dial_set_zero_db(GTK_DIAL(cell->volume_dial), zero_db_value);
+  gtk_dial_set_can_control(GTK_DIAL(cell->volume_dial), TRUE);
+
+  cell->volume_label = gtk_label_new(NULL);
+  gtk_widget_add_css_class(cell->volume_label, "gain");
+
+  g_signal_connect(
+    cell->volume_dial,
+    "value-changed",
+    G_CALLBACK(mixer_combined_volume_changed),
+    cell
+  );
+
+  gtk_box_append(GTK_BOX(cell->volume_box), cell->volume_dial);
+  gtk_box_append(GTK_BOX(cell->volume_box), cell->volume_label);
+
+  cell->pan_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+  gtk_widget_set_hexpand(cell->pan_box, TRUE);
+  gtk_widget_set_vexpand(cell->pan_box, TRUE);
+
+  cell->pan_dial = gtk_dial_new_with_range(
+    -MIXER_PAN_RANGE,
+    MIXER_PAN_RANGE,
+    1.0,
+    MIXER_PAN_RANGE / 5.0
+  );
+  gtk_widget_set_vexpand(cell->pan_dial, TRUE);
+  gtk_dial_set_has_origin(GTK_DIAL(cell->pan_dial), TRUE);
+  gtk_dial_set_can_control(GTK_DIAL(cell->pan_dial), TRUE);
+  gtk_dial_set_round_digits(GTK_DIAL(cell->pan_dial), 0);
+
+  cell->pan_label = gtk_label_new(NULL);
+  gtk_widget_add_css_class(cell->pan_label, "gain");
+
+  g_signal_connect(
+    cell->pan_dial,
+    "value-changed",
+    G_CALLBACK(mixer_combined_pan_changed),
+    cell
+  );
+
+  gtk_box_append(GTK_BOX(cell->pan_box), cell->pan_dial);
+  gtk_box_append(GTK_BOX(cell->pan_box), cell->pan_label);
+
+  gtk_stack_add_named(cell->left_stack, cell->volume_box, STACK_PAGE_COMBINED);
+  gtk_stack_add_named(cell->right_stack, cell->pan_box, STACK_PAGE_COMBINED);
+
+  GtkWidget *mix_label_left = g_object_get_data(
+    G_OBJECT(cell->left_widget),
+    "mix_label_left"
+  );
+  GtkWidget *mix_label_right = g_object_get_data(
+    G_OBJECT(cell->left_widget),
+    "mix_label_right"
+  );
+  GtkWidget *source_label_top = g_object_get_data(
+    G_OBJECT(cell->left_widget),
+    "source_label_top"
+  );
+  GtkWidget *source_label_bottom = g_object_get_data(
+    G_OBJECT(cell->left_widget),
+    "source_label_bottom"
+  );
+
+  if (cell->volume_box) {
+    g_object_set_data(
+      G_OBJECT(cell->volume_box),
+      "mix_label_left",
+      mix_label_left
+    );
+    g_object_set_data(
+      G_OBJECT(cell->volume_box),
+      "mix_label_right",
+      mix_label_right
+    );
+    g_object_set_data(
+      G_OBJECT(cell->volume_box),
+      "source_label_top",
+      source_label_top
+    );
+    g_object_set_data(
+      G_OBJECT(cell->volume_box),
+      "source_label_bottom",
+      source_label_bottom
+    );
+    add_mixer_hover_controller(cell->volume_box);
+  }
+
+  if (cell->pan_box) {
+    g_object_set_data(
+      G_OBJECT(cell->pan_box),
+      "mix_label_left",
+      mix_label_left
+    );
+    g_object_set_data(
+      G_OBJECT(cell->pan_box),
+      "mix_label_right",
+      mix_label_right
+    );
+    g_object_set_data(
+      G_OBJECT(cell->pan_box),
+      "source_label_top",
+      source_label_top
+    );
+    g_object_set_data(
+      G_OBJECT(cell->pan_box),
+      "source_label_bottom",
+      source_label_bottom
+    );
+    add_mixer_hover_controller(cell->pan_box);
+  }
+
+  cell->has_combined = TRUE;
+}
+
+static void mixer_state_init_combined_cells(struct mixer_state *state) {
+  for (int i = 0; i < state->pair_count; i++) {
+    struct mixer_pair *pair = &state->pairs[i];
+
+    pair->state = state;
+    pair->pair_index = i;
+    pair->left_mix = i * 2;
+    pair->right_mix = pair->left_mix + 1;
+
+    for (int j = 0; j < state->input_count; j++) {
+      struct mixer_combined_cell *cell = &pair->cells[j];
+
+      cell->pair = pair;
+      cell->left_elem = state->elems[pair->left_mix][j];
+      cell->right_elem = state->elems[pair->right_mix][j];
+      cell->left_stack =
+        GTK_STACK(state->stacks[pair->left_mix][j]);
+      cell->right_stack =
+        GTK_STACK(state->stacks[pair->right_mix][j]);
+      cell->left_widget = state->gain_widgets[pair->left_mix][j];
+      cell->right_widget = state->gain_widgets[pair->right_mix][j];
+
+      if (!cell->left_elem || !cell->right_elem ||
+          !cell->left_stack || !cell->right_stack)
+        continue;
+
+      mixer_combined_create_widgets(cell);
+
+      alsa_elem_add_callback(
+        cell->left_elem,
+        mixer_combined_elem_updated,
+        cell
+      );
+      alsa_elem_add_callback(
+        cell->right_elem,
+        mixer_combined_elem_updated,
+        cell
+      );
+
+      mixer_combined_sync(cell);
+    }
+  }
+}
+
+static void mixer_pair_update_toggle_label(struct mixer_pair *pair) {
+  if (!pair->toggle_label)
+    return;
+
+  gtk_label_set_text(
+    GTK_LABEL(pair->toggle_label),
+    pair->combined ? "Stereo" : "Dual"
+  );
+}
+
+static void mixer_pair_set_combined(struct mixer_pair *pair, gboolean combined) {
+  struct mixer_state *state = pair->state;
+
+  if (!state)
+    return;
+
+  if (pair->combined == combined)
+    return;
+
+  pair->combined = combined;
+  mixer_pair_update_toggle_label(pair);
+
+  char label[16];
+
+  if (combined) {
+    snprintf(
+      label,
+      sizeof(label),
+      "Mix %c/%c",
+      'A' + pair->left_mix,
+      'A' + pair->right_mix
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_left[pair->left_mix]),
+      label
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_right[pair->left_mix]),
+      label
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_left[pair->right_mix]),
+      "Pan"
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_right[pair->right_mix]),
+      "Pan"
+    );
+  } else {
+    snprintf(
+      label,
+      sizeof(label),
+      "Mix %c",
+      'A' + pair->left_mix
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_left[pair->left_mix]),
+      label
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_right[pair->left_mix]),
+      label
+    );
+    snprintf(
+      label,
+      sizeof(label),
+      "Mix %c",
+      'A' + pair->right_mix
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_left[pair->right_mix]),
+      label
+    );
+    gtk_label_set_text(
+      GTK_LABEL(state->mix_labels_right[pair->right_mix]),
+      label
+    );
+  }
+
+  for (int i = 0; i < state->input_count; i++) {
+    struct mixer_combined_cell *cell = &pair->cells[i];
+
+    if (!cell->has_combined)
+      continue;
+
+    const char *page = combined ? STACK_PAGE_COMBINED : STACK_PAGE_SPLIT;
+
+    gtk_stack_set_visible_child_name(cell->left_stack, page);
+    gtk_stack_set_visible_child_name(cell->right_stack, page);
+
+    if (combined)
+      mixer_combined_sync(cell);
+  }
+}
+
+static void mixer_pair_toggle_notify(
+  GtkSwitch *widget,
+  GParamSpec *pspec,
+  gpointer    user_data
+) {
+  struct mixer_pair *pair = user_data;
+
+  mixer_pair_set_combined(pair, gtk_switch_get_active(widget));
+}
+
 static struct routing_snk *get_mixer_r_snk(
   struct alsa_card *card,
   int               input_num
@@ -91,21 +718,27 @@ GtkWidget *create_mixer_controls(struct alsa_card *card) {
 
   GArray *elems = card->elems;
 
-  GtkWidget *mix_labels_left[MAX_MIX_OUT];
-  GtkWidget *mix_labels_right[MAX_MIX_OUT];
+  struct mixer_state *state = g_new0(struct mixer_state, 1);
+  state->card = card;
+  state->top = top;
+  state->mixer_top = mixer_top;
+  state->mix_count = card->routing_in_count[PC_MIX];
+  state->input_count = card->routing_out_count[PC_MIX];
+  state->pair_count = state->mix_count / 2;
+  g_object_set_data_full(G_OBJECT(top), "mixer-state", state, g_free);
 
   // create the Mix X labels on the left and right of the grid
   for (int i = 0; i < card->routing_in_count[PC_MIX]; i++) {
     char name[10];
     snprintf(name, 10, "Mix %c", i + 'A');
 
-    GtkWidget *l_left = mix_labels_left[i] = gtk_label_new(name);
+    GtkWidget *l_left = state->mix_labels_left[i] = gtk_label_new(name);
     gtk_grid_attach(
       GTK_GRID(mixer_top), l_left,
       0, i + 2, 1, 1
     );
 
-    GtkWidget *l_right = mix_labels_right[i] = gtk_label_new(name);
+    GtkWidget *l_right = state->mix_labels_right[i] = gtk_label_new(name);
     gtk_grid_attach(
       GTK_GRID(mixer_top), l_right,
       card->routing_out_count[PC_MIX] + 1, i + 2, 1, 1
@@ -143,7 +776,12 @@ GtkWidget *create_mixer_controls(struct alsa_card *card) {
 
     // create the gain control and attach to the grid
     GtkWidget *w = make_gain_alsa_elem(elem, 1, WIDGET_GAIN_TAPER_LOG, 0);
-    gtk_grid_attach(GTK_GRID(mixer_top), w, input_num + 1, mix_num + 2, 1, 1);
+    GtkWidget *stack = gtk_stack_new();
+    gtk_widget_set_hexpand(stack, TRUE);
+    gtk_widget_set_vexpand(stack, TRUE);
+    gtk_stack_add_named(GTK_STACK(stack), w, STACK_PAGE_SPLIT);
+    gtk_stack_set_visible_child_name(GTK_STACK(stack), STACK_PAGE_SPLIT);
+    gtk_grid_attach(GTK_GRID(mixer_top), stack, input_num + 1, mix_num + 2, 1, 1);
 
     // look up the r_snk entry for the mixer input number
     struct routing_snk *r_snk = get_mixer_r_snk(card, input_num + 1);
@@ -173,14 +811,68 @@ GtkWidget *create_mixer_controls(struct alsa_card *card) {
       );
     }
 
-    g_object_set_data(G_OBJECT(w), "mix_label_left", mix_labels_left[mix_num]);
-    g_object_set_data(G_OBJECT(w), "mix_label_right", mix_labels_right[mix_num]);
+    g_object_set_data(G_OBJECT(w), "mix_label_left", state->mix_labels_left[mix_num]);
+    g_object_set_data(G_OBJECT(w), "mix_label_right", state->mix_labels_right[mix_num]);
     g_object_set_data(G_OBJECT(w), "source_label_top", r_snk->mixer_label_top);
     g_object_set_data(G_OBJECT(w), "source_label_bottom", r_snk->mixer_label_bottom);
 
     // add hover controller to the gain widget
     add_mixer_hover_controller(w);
 
+    state->stacks[mix_num][input_num] = stack;
+    state->gain_widgets[mix_num][input_num] = w;
+    state->elems[mix_num][input_num] = elem;
+
+  }
+
+  mixer_state_init_combined_cells(state);
+
+  for (int i = 0; i < state->pair_count; i++) {
+    struct mixer_pair *pair = &state->pairs[i];
+
+    GtkWidget *toggle_box = gtk_box_new(GTK_ORIENTATION_VERTICAL, 4);
+    gtk_widget_set_halign(toggle_box, GTK_ALIGN_CENTER);
+    gtk_widget_set_valign(toggle_box, GTK_ALIGN_CENTER);
+
+    GtkWidget *label = gtk_label_new(NULL);
+    gtk_widget_add_css_class(label, "mixer-label");
+    pair->toggle_label = label;
+    gtk_box_append(GTK_BOX(toggle_box), label);
+
+    GtkWidget *toggle = gtk_switch_new();
+    gtk_box_append(GTK_BOX(toggle_box), toggle);
+    pair->toggle_box = toggle_box;
+    pair->toggle_switch = GTK_SWITCH(toggle);
+
+    g_signal_connect(
+      toggle,
+      "notify::active",
+      G_CALLBACK(mixer_pair_toggle_notify),
+      pair
+    );
+
+    char tooltip[64];
+    snprintf(
+      tooltip,
+      sizeof(tooltip),
+      "Combine Mix %c/%c into stereo",
+      'A' + pair->left_mix,
+      'A' + pair->right_mix
+    );
+    gtk_widget_set_tooltip_text(toggle_box, tooltip);
+
+    gtk_grid_attach(
+      GTK_GRID(mixer_top),
+      toggle_box,
+      state->input_count + 2,
+      pair->left_mix + 2,
+      1,
+      2
+    );
+
+    gtk_switch_set_active(pair->toggle_switch, FALSE);
+    pair->combined = TRUE;
+    mixer_pair_set_combined(pair, FALSE);
   }
 
   update_mixer_labels(card);

--- a/src/window-mixer.c
+++ b/src/window-mixer.c
@@ -350,14 +350,6 @@ static void mixer_combined_volume_changed(
 
   cell->volume_norm = volume_norm;
 
-  gboolean reset_pan = FALSE;
-
-  if (alsa_value == cell->zero_db_value)
-    reset_pan = TRUE;
-
-  if (reset_pan)
-    cell->pan_norm = 0.0;
-
   cell->stored_pan_norm = cell->pan_norm;
   cell->stored_pan_valid = TRUE;
 
@@ -376,11 +368,6 @@ static void mixer_combined_volume_changed(
   cell->updating = TRUE;
   alsa_set_elem_value(cell->left_elem, left_value);
   alsa_set_elem_value(cell->right_elem, right_value);
-
-  if (reset_pan && cell->pan_dial) {
-    gtk_dial_set_value(GTK_DIAL(cell->pan_dial), 0.0);
-    mixer_combined_update_pan_label(cell);
-  }
 
   mixer_combined_update_volume_label(cell, alsa_value);
   cell->updating = FALSE;


### PR DESCRIPTION
I was missing a mode for stereo mixes, so I added one.

## Summary
- add infrastructure for stereo pairing, including combined volume and pan controls for mixer pairs
- wrap mixer cells in stacks and introduce GtkSwitch-based toggles that swap between dual and stereo presentations
- synchronize combined widgets with ALSA element updates to keep UI feedback aligned
- remember the last values written for each combined mixer cell and reuse the stored pan when ALSA reports the same state

## Example
![Stereo-Mix](https://github.com/user-attachments/assets/e6063b42-e6ac-4210-aa8b-fb93c53340d6)

## Disclaimer
I vibe-coded this together with ChatGPT/Codex.
