### PR TITLE
Add a note to the 4th gen (big) docs about firmware versions

### DIFF
--- a/docs/iface-4th-gen-big.md
+++ b/docs/iface-4th-gen-big.md
@@ -20,7 +20,8 @@ alsa-scarlett-gui.
 > The latest firmware version for these interfaces is not yet suppported
 > by the driver. For now, you'll have to install the version in the
 > [scarlett4-firmware](https://github.com/geoffreybennett/scarlett4-firmware)
-> repo using `fcp-tool`. See #169 for more details.
+> repo using `fcp-tool`. See [#169](https://github.com/geoffreybennett/alsa-scarlett-gui/issues/169)
+> for more details.
 
 ## Main Window
 

--- a/docs/iface-4th-gen-big.md
+++ b/docs/iface-4th-gen-big.md
@@ -16,6 +16,12 @@ installed
 need to do that (and update the firmware) before you can use
 alsa-scarlett-gui.
 
+> [!IMPORTANT]
+> The latest firmware version for these interfaces is not yet suppported
+> by the driver. For now, you'll have to install the version in the
+> [scarlett4-firmware](https://github.com/geoffreybennett/scarlett4-firmware)
+> repo using `fcp-tool`. See #169 for more details.
+
 ## Main Window
 
 The main window is divided into three sections:


### PR DESCRIPTION
The latest version of the firmware is not yet supported (#169) so this adds a note to the docs to clarify that, since this is pretty much the only thing preventing these from just being plug-and-play. This note is admittedly a little obnoxiously big but I think it's warranted given that being on too new of a firmware version completely breaks support for these interfaces.