### PR TITLE
Fix const qualifier warning in sim_card_name()

### DIFF
--- a/src/alsa-sim.c
+++ b/src/alsa-sim.c
@@ -465,9 +465,10 @@ static void alsa_config_to_new_card(
 static char *sim_card_name(const char *fn) {
 
   // strdup fn and remove path (if any)
-  char *name = strrchr(fn, '/');
-  if (name)
-    name = strdup(name + 1);
+  const char *base = strrchr(fn, '/');
+  char *name;
+  if (base)
+    name = strdup(base + 1);
   else
     name = strdup(fn);
 


### PR DESCRIPTION
## Summary
- `strrchr()` returns `const char *` when called on a `const char *` argument, but the result was assigned to `char *` in `sim_card_name()`
- This triggers `-Wdiscarded-qualifiers`, which breaks the build due to `-Werror`
- Fix uses a separate `const char *` variable for the `strrchr()` result

## Test plan
- [x] Verified `make clean && make -j4` succeeds without warnings
