### PR TITLE
remove const from fn declaration

### DIFF
--- a/src/alsa-sim.c
+++ b/src/alsa-sim.c
@@ -462,7 +462,7 @@ static void alsa_config_to_new_card(
 
 // return the basename of fn (no path, no extension)
 // e.g. "/home/user/file.ext" -> "file"
-static char *sim_card_name(const char *fn) {
+static char *sim_card_name(char *fn) {
 
   // strdup fn and remove path (if any)
   char *name = strrchr(fn, '/');


### PR DESCRIPTION
Fixes https://github.com/geoffreybennett/alsa-scarlett-gui/issues/226
C23 changed strrchr such that a const arg returns a const which makes name immutable. See [explanation](https://stackoverflow.com/a/1436814)