### PR TITLE
fix: const correctness in sim_card_name

### DIFF
--- a/src/alsa-sim.c
+++ b/src/alsa-sim.c
@@ -463,18 +463,14 @@ static void alsa_config_to_new_card(
 // return the basename of fn (no path, no extension)
 // e.g. "/home/user/file.ext" -> "file"
 static char *sim_card_name(const char *fn) {
+  /* strdup fn and remove path (if any) */
+  const char *s = strrchr(fn, '/');
+  char *name = s ? strdup(s + 1) : strdup(fn);
+  if (!name) return NULL;
 
-  // strdup fn and remove path (if any)
-  char *name = strrchr(fn, '/');
-  if (name)
-    name = strdup(name + 1);
-  else
-    name = strdup(fn);
-
-  // remove extension
+  /* remove extension */
   char *dot = strrchr(name, '.');
-  if (dot)
-    *dot = '\0';
+  if (dot) *dot = '\0';
 
   return name;
 }

--- a/src/window-mixer.c
+++ b/src/window-mixer.c
@@ -128,7 +128,7 @@ GtkWidget *create_mixer_controls(struct alsa_card *card) {
         strncmp(elem->name, "Matrix ", 7))
       continue;
 
-    char *mix_str = strstr(elem->name, "Mix ");
+    const char *mix_str = strstr(elem->name, "Mix ");
     if (!mix_str)
       continue;
 


### PR DESCRIPTION
After upgrading to Fedora 44 (gcc version 16.1.1) I had this warning treated as error:

```log
$ make -j8
cc -MT alsa-sim.o -MMD -MP -MF .deps/alsa-sim.d -ggdb -fno-omit-frame-pointer -fPIE -O2 -Wall -Werror -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -DVERSION=\"292b\" -Wno-error=deprecated-declarations -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/sysprof-6 -pthread -I/usr/include/gtk-4.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/glycin-2 -I/usr/include/cairo -I/usr/include/libxml2 -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/pixman-1 -I/usr/include/graphene-1.0 -I/usr/lib64/graphene-1.0/include -mfpmath=sse -msse -msse2 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -DWITH_GZFILEOP -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/sysprof-6 -pthread  -c -o alsa-sim.o alsa-sim.c
alsa-sim.c: In function ‘sim_card_name’:
alsa-sim.c:468:16: error: initialization discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
  468 |   char *name = strrchr(fn, '/');
      |                ^~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:43: alsa-sim.o] Error 1
```

This rewritten version of `sim_card_name` fixes the build error `discarded 'const' qualifier treated as error` but it does not change the function interface (input and output).

---

Edit.

A similar problem found in `window-mixer.c`:
```log
window-mixer.c:131:21: error: initialization discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
```